### PR TITLE
Implement Python wrapper 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ CMakeFiles
 cmake_install.cmake
 CMakeCache.txt
 Makefile
+py-wrapper/gbe.h
+py-wrapper/libgbe.a

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "py-wrapper/pybind11"]
+	path = py-wrapper/pybind11
+	url = https://github.com/pybind/pybind11

--- a/README.md
+++ b/README.md
@@ -31,6 +31,23 @@ Tileset view:
 
 ![Tileset window](https://raw.githubusercontent.com/psaikko/gbe/master/img/Tileset_screenshot.png)
 
+Python wrapper
+---
+To install
+1. `git clone --recursive https://github.com/psaikko/gbe/` 
+2. `cmake . && make libgbe`
+3. `cp {gbe.h,libgbe.a} py-wrapper/`
+4. `pip install py-wrapper/`
+
+Usage
+
+```
+import libgbe
+gbe = GBE("path/to/rom")
+gbe.run(70224)
+gbe.display()
+```
+
 TODOs
 ---
 - Full savestates

--- a/py-wrapper/CMakeLists.txt
+++ b/py-wrapper/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(libgbe)
+
+add_subdirectory(pybind11)
+pybind11_add_module(libgbe wrapper.cpp)
+target_link_libraries(libgbe PUBLIC ${CMAKE_SOURCE_DIR}/libgbe.a)

--- a/py-wrapper/setup.py
+++ b/py-wrapper/setup.py
@@ -1,0 +1,69 @@
+import os
+import re
+import sys
+import platform
+import subprocess
+
+from setuptools import setup, Extension
+from setuptools.command.build_ext import build_ext
+from distutils.version import LooseVersion
+
+
+class CMakeExtension(Extension):
+    def __init__(self, name, sourcedir=''):
+        Extension.__init__(self, name, sources=[])
+        self.sourcedir = os.path.abspath(sourcedir)
+
+
+class CMakeBuild(build_ext):
+    def run(self):
+        try:
+            out = subprocess.check_output(['cmake', '--version'])
+        except OSError:
+            raise RuntimeError("CMake must be installed to build the following extensions: " +
+                               ", ".join(e.name for e in self.extensions))
+
+        if platform.system() == "Windows":
+            cmake_version = LooseVersion(re.search(r'version\s*([\d.]+)', out.decode()).group(1))
+            if cmake_version < '3.1.0':
+                raise RuntimeError("CMake >= 3.1.0 is required on Windows")
+
+        for ext in self.extensions:
+            self.build_extension(ext)
+
+    def build_extension(self, ext):
+        extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
+        cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
+                      '-DPYTHON_EXECUTABLE=' + sys.executable]
+
+        cfg = 'Debug' if self.debug else 'Release'
+        build_args = ['--config', cfg]
+
+        if platform.system() == "Windows":
+            cmake_args += ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}'.format(cfg.upper(), extdir)]
+            if sys.maxsize > 2**32:
+                cmake_args += ['-A', 'x64']
+            build_args += ['--', '/m']
+        else:
+            cmake_args += ['-DCMAKE_BUILD_TYPE=' + cfg]
+            build_args += ['--', '-j2']
+
+        env = os.environ.copy()
+        env['CXXFLAGS'] = '{} -DVERSION_INFO=\\"{}\\"'.format(env.get('CXXFLAGS', ''),
+                                                              self.distribution.get_version())
+        if not os.path.exists(self.build_temp):
+            os.makedirs(self.build_temp)
+        subprocess.check_call(['cmake', ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env)
+        subprocess.check_call(['cmake', '--build', '.'] + build_args, cwd=self.build_temp)
+
+setup(
+    name='libgbe',
+    version='0.0.1',
+    author='Chang Rajani',
+    author_email='-',
+    description='Gameboy Emulator python wrapper',
+    long_description='',
+    ext_modules=[CMakeExtension('libgbe')],
+    cmdclass=dict(build_ext=CMakeBuild),
+    zip_safe=False,
+)

--- a/py-wrapper/wrapper.cpp
+++ b/py-wrapper/wrapper.cpp
@@ -1,0 +1,15 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "gbe.h"
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(libgbe, m) {
+    py::class_<gbe>(m, "GBE")
+        .def(py::init< std::string >())
+        .def("display", &gbe::display)
+        .def("run", &gbe::run)
+        .def("input", &gbe::input)
+        .def("read_memory", &gbe::mem);
+}


### PR DESCRIPTION
* Uses pybind11 as git submodule
* Wrote instructions in README

TODO return numpy array instead of python list from `gbe.display()`, but not critical.
TODO Figure out better way than copying header and static library to `py-wrapper` folder